### PR TITLE
Ignore utf-8 decoding errors from sseclient

### DIFF
--- a/faux/faux.py
+++ b/faux/faux.py
@@ -118,7 +118,12 @@ class FauxUrbitListener():
         def urbit_listener(message, _):
             asyncio.run(urbit_action(message, _))
 
-        self.urbit_client.listen(urbit_listener)
+        while True:
+            try:
+                self.urbit_client.listen(urbit_listener)
+            except UnicodeDecodeError:
+                continue
+
 
 def discord_runner(group):
     listener = FauxDiscordListener()


### PR DESCRIPTION
Partial fix for https://github.com/midsum-salrux/faux/issues/4

Emojis posted in discord will no longer crash the urbit listener, but still appear garbled.