### PR TITLE
Change how static_login is called and pin discord.py version

### DIFF
--- a/faux/faux.py
+++ b/faux/faux.py
@@ -131,9 +131,9 @@ class FauxDiscordListener(discord.Client):
             result = { "text": '' }
             if description:
                 description = f'''
-                
+
                 {description}
-                
+
                 '''
             if message_type == MessageType.REDDIT:
                 result["text"] = f'''
@@ -146,7 +146,7 @@ class FauxDiscordListener(discord.Client):
                     [{orig_author_name}]({orig_author_url}): {description}
                 '''
             elif message_type == MessageType.DISCORD:
-                result["text"] = f'__{author}__: {title}{description}{parsed}'        
+                result["text"] = f'__{author}__: {title}{description}{parsed}'
             elif message_type == MessageType.GIF:
                 result["text"] = f'__{author}__:'
             else:
@@ -199,7 +199,7 @@ class FauxUrbitListener(discord.http.HTTPClient):
 
     def run(self):
         async def urbit_action(message, _):
-            await self.static_login(DISCORD_TOKEN)
+            await self.static_login(DISCORD_TOKEN, bot=DISCORD_TOKEN)
             if self.group["urbit_ship"] == message.host_ship:
                 matching_channels = list(
                     filter(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/midsum-salrux/faux",
     packages=setuptools.find_packages(),
-    install_requires=['quinnat', 'discord.py'],
+    install_requires=['quinnat', 'discord.py ==1.7.3'],
     classifiers=[],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
https://github.com/Rapptz/discord.py/blob/59aa1a0e5f785116f2d21204e755071c38daccca/discord/http.py#L291
https://github.com/Rapptz/discord.py/blob/master/discord/http.py#L542

>so the arguments to HTTPClient.static_login() are different depending on the version of discord.py
>the way it's currently called by us is correct for the bleeding-edge version but not for the version distributed on pypi
>I'm going to make it use the latter arguments and pin the version.
